### PR TITLE
jf: remove persist.sys.usb.config override

### DIFF
--- a/jf-common.mk
+++ b/jf-common.mk
@@ -54,10 +54,6 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/com.nxp.mifare.xml:system/etc/permissions/com.nxp.mifare.xml \
     frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml
 
-# System Properties
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
-    persist.sys.usb.config=mtp
-
 # Device uses high-density artwork where available
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi


### PR DESCRIPTION
The variable persist.sys.usb.config is no longer honored by the framework,
and it's presence causes unnecessary toggling of the USB driver, which
disonnects ADB and makes the device's connection unstable.

Delete it.

Bug: 21404762
Bug: 18905620
Change-Id: Ie456319637de15e27ec74cad4884bb7724110896
